### PR TITLE
Add schema dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,6 @@
   :url "http://github.com/juxt/aero"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies []
+  :dependencies [[prismatic/schema "0.4.3"]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0-beta3"]]}})


### PR DESCRIPTION
Not sure if there was a reason for it, but schema.core is required in aero.core, but it isn't specified as a dependency.
