### PR TITLE
Reading empty config file throws an exception

### DIFF
--- a/src/aero/core.clj
+++ b/src/aero/core.clj
@@ -34,7 +34,8 @@
          config
          (with-open [pr (java.io.PushbackReader. (io/reader r))]
            (edn/read
-            {:readers (readers {:profile (or profile :default)
+            {:eof {}
+             :readers (readers {:profile (or profile :default)
                                 :hostname hostname})}
             pr))]
      (when schema

--- a/src/aero/core.clj
+++ b/src/aero/core.clj
@@ -34,7 +34,7 @@
          config
          (with-open [pr (java.io.PushbackReader. (io/reader r))]
            (edn/read
-            {:eof {}
+            {:eof nil
              :readers (readers {:profile (or profile :default)
                                 :hostname hostname})}
             pr))]

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -9,8 +9,8 @@
 (deftest basic-test
   (let [config (read-config "test/aero/config.edn")]
     (is (= "Hello World!" (:greeting config))))
-  (testing "Reading empty config returns empty map"
-    (is (= {} (read-config "test/aero/empty-config.edn")))))
+  (testing "Reading empty config returns nil"
+    (is (= nil (read-config "test/aero/empty-config.edn")))))
 
 (deftest hostname-test
   (is (=

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -8,7 +8,9 @@
 
 (deftest basic-test
   (let [config (read-config "test/aero/config.edn")]
-    (is (= "Hello World!" (:greeting config)))))
+    (is (= "Hello World!" (:greeting config))))
+  (testing "Reading empty config returns empty map"
+    (is (= {} (read-config "test/aero/empty-config.edn")))))
 
 (deftest hostname-test
   (is (=


### PR DESCRIPTION
Hey Malcolm,

I noticed that reading empty config files will throw an exception. I thought maybe returning an empty map would be a better default, hence this pull request.

In my usecase I look at several possible config files, reading them with aero and then merging together. None of those are mandatory to be present and I wouldn't want the app to fail if one of the files in the chain got set empty by an admin.

(Haven't bumped the version on purpose)

Good luck
