### PR TITLE
include reader to use current config files location for relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,11 @@ can specify multiple hostnames in a set.
 Use to include another config file. This allows you to split your config files
 to prevent them from getting too large.
 
+Note: `#include` will respect relative file paths in respect to the config files path *NOT* the current working directory.
+
 ``` clojure
-{:webserver #include "resources/webserver.edn"
- :analytics #include "resources/analytics.edn"}
+{:webserver #include "webserver.edn"
+ :analytics #include "analytics.edn"}
 ```
 
 ### Define your own

--- a/resources/hello.edn
+++ b/resources/hello.edn
@@ -1,0 +1,1 @@
+{:hello :world}

--- a/resources/test.edn
+++ b/resources/test.edn
@@ -1,0 +1,1 @@
+{:speak #include "hello.edn"}

--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -4,7 +4,7 @@
  :smart-term #join ["Terminal is " #or [#env NONE "smart"]]
  :flavor-string #join ["My favorite flavor is " #or [#env TERM "flaa"] " " #myflavor :favorite]
  :test ^:ref [:greeting]
- :remote #include "test/aero/included.edn"
+ :remote #include "included.edn"
  :test-nested ^:ref [:test]
  :port #profile {:dev 8000
                  :prod 80}

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -79,6 +79,10 @@
   (let [config (read-config "test/aero/config.edn" {:profile :dev})]
     (is (= "dummy" (:dummy config)))))
 
+(deftest resource-test
+  (let [config (read-config (io/resource "test.edn") {:profile :dev})]
+    (is (= config {:speak {:hello :world}}))))
+
 (deftest dangling-ref-test
   (is
    (=


### PR DESCRIPTION
This PR resolves issue #12 as you can now use relative paths inside the resources dir.
