### PR TITLE
Numeric readers

### DIFF
--- a/src/aero/core.clj
+++ b/src/aero/core.clj
@@ -28,6 +28,14 @@
   [opts tag value]
   (first (filter some? value)))
 
+(defmethod reader 'long
+  [opts tag value]
+  (Long/parseLong (str value)))
+
+(defmethod reader 'double
+  [opts tag value]
+  (Double/parseDouble (str value)))
+
 (defmethod reader 'profile
   [{:keys [profile]} tag value]
   (cond (contains? value profile) (get value profile)

--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -8,6 +8,8 @@
  :test-nested ^:ref [:test]
  :port #profile {:dev 8000
                  :prod 80}
+ :long #long "1234"
+ :double #double "4567.8"
  :dummy #or [#env "DUMMY" "dummy"]
  :triple-or #or [#env "DUMMY" #prop "DUMMY" "dummy"]
  :prop #prop "DUMMY"}

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -63,7 +63,13 @@
 (deftest numeric-test
   (let [config (read-config "test/aero/config.edn")]
     (is (= 1234 (:long config)))
-    (is (= 4567.8 (:double config)))))
+    (is (= 4567.8 (:double config))))
+  (System/setProperty "FOO" "123")
+  (let [config (read-config "test/aero/long_prop.edn")]
+    (is (= 123 (:long-prop config))))
+  (System/clearProperty "FOO"))
+
+
 
 (deftest format-test
   (let [config (read-config "test/aero/config.edn")]

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -60,6 +60,11 @@
     (is (= "ABC123" (:prop config))))
   (System/clearProperty "DUMMY"))
 
+(deftest numeric-test
+  (let [config (read-config "test/aero/config.edn")]
+    (is (= 1234 (:long config)))
+    (is (= 4567.8 (:double config)))))
+
 (deftest format-test
   (let [config (read-config "test/aero/config.edn")]
     (is (= (format "My favorite flavor is %s %s" (System/getenv "TERM") :chocolate)

--- a/test/aero/long_prop.edn
+++ b/test/aero/long_prop.edn
@@ -1,0 +1,1 @@
+{:long-prop #long #prop "FOO"}


### PR DESCRIPTION
i have a config which requires some numeric values from the environment, but #env delivers strings

solution - #long and #double 
