### PR TITLE
Namespace aero generated keywords for simpler debugging

### DIFF
--- a/src/aero/core.clj
+++ b/src/aero/core.clj
@@ -94,7 +94,7 @@
           (io/file (-> source io/file .getParent) include))]
     (if (.exists fl)
       fl
-      (java.io.StringReader. (pr-str {:missing-include include})))))
+      (java.io.StringReader. (pr-str {:aero/missing-include include})))))
 
 (defn resource-resolver [_ include]
   (io/resource include))

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -116,7 +116,7 @@
     (is (read-config source {:profile  :map
                              :resolver {:sub-includes (io/resource "aero/sub/includes.edn")
                                         :valid-file   (io/resource "aero/valid.edn")}}))
-    (is (:missing-include (read-config source {:profile :file-does-not-exist})))))
+    (is (:aero/missing-include (read-config source {:profile :file-does-not-exist})))))
 
 (deftest dangling-ref-test
   (is


### PR DESCRIPTION
Feel free to not merge this - I have been caught wondering how `:missing-include` had turning up in my data structure. I think having namespaced keywords would help understand what caused this.
