### PR TITLE
Implement reader for #keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,15 @@ can specify multiple hostnames in a set.
                     :default 8082}}}
 ```
 
-### long, double
+### long, double, keyword
 
-Use to parse a `String` value into a `Long` or `Double`
+Use to parse a `String` value into a `Long`, `Double` or keyword
 
 ``` clojure
 {:webserver
   {:port #long #or [#env PORT 8080]
-   :factor #double #env FACTOR}}
+   :factor #double #env FACTOR
+   :mode #keyword #env MODE}}
 ```
 
 ### user

--- a/src/aero/core.clj
+++ b/src/aero/core.clj
@@ -36,6 +36,12 @@
   [opts tag value]
   (Double/parseDouble (str value)))
 
+(defmethod reader 'keyword
+  [opts tag value]
+  (if (keyword? value)
+    value
+    (keyword (str value))))
+
 (defmethod reader 'profile
   [{:keys [profile]} tag value]
   (cond (contains? value profile) (get value profile)

--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -10,6 +10,9 @@
                  :prod 80}
  :long #long "1234"
  :double #double "4567.8"
+ :keyword #keyword "foo/bar"
+ :already-a-keyword #keyword :foo/bar
+ :env-keyword #keyword #or [#env KEYWORD "abc"]
  :dummy #or [#env "DUMMY" "dummy"]
  :triple-or #or [#env "DUMMY" #prop "DUMMY" "dummy"]
  :prop #prop "DUMMY"

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -74,7 +74,11 @@
     (is (= 123 (:long-prop config))))
   (System/clearProperty "FOO"))
 
-
+(deftest keyword-test
+  (let [config (read-config "test/aero/config.edn")]
+    (is (= :foo/bar (:keyword config)))
+    (is (= :foo/bar (:already-a-keyword config)))
+    (is (= :abc (:env-keyword config)))))
 
 (deftest format-test
   (let [config (read-config "test/aero/config.edn")]


### PR DESCRIPTION
The reader for #keyword attempts to convert the value to a keyword,
unless the value already is a keyword in which it just returns the value unchanged
