### PR TITLE
Add `envf` exactly as it appears in Joplin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Use `#env` to reference an environment variable.
 
 It is considered bad practice to use environment variables for passwords and other confidential information. This is because it is very easy for anyone to read a process's environment (e.g. via `ps -ef`). Environment variables are also commonly dumped out in a debugging sessions. Instead you should use `#include` - see [here](#hide-passwords-in-local-private-files).
 
+### envf
+
+Use `#envf` to insert environment variables into a formatted string.
+
+```clojure
+{:database #envf ["protocol://%s:%s" DATABASE_HOST DATABASE_NAME]}
+```
+
 ### or
 
 Use `#or` when you want to provide a list of possibilities, perhaps with a default and the end.

--- a/src/aero/core.clj
+++ b/src/aero/core.clj
@@ -21,6 +21,12 @@
   [opts tag value]
   (System/getenv (str value)))
 
+(defmethod reader 'envf
+  [opts tag value]
+  (let [[fmt & args] value]
+    (apply format fmt
+           (map #(System/getenv (str %)) args))))
+
 (defmethod reader 'prop
   [opts tag value]
   (System/getProperty (str value)))

--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -2,6 +2,7 @@
  :flavor #myflavor :favorite
  :dumb-term #join ["Terminal is " #env TERM]
  :smart-term #join ["Terminal is " #or [#env NONE "smart"]]
+ :dumb-term-envf #envf ["Terminal is %s" TERM]
  :flavor-string #join ["My favorite flavor is " #or [#env TERM "flaa"] " " #myflavor :favorite]
  :test ^:ref [:greeting]
  :remote #include "included.edn"

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -48,12 +48,17 @@
   (let [config (read-config "test/aero/config.edn")]
     (is (= :chocolate (:flavor config)))))
 
-(deftest envf-test
+(deftest join-test
   (let [config (read-config "test/aero/config.edn")]
     (is (= (format "Terminal is %s" (System/getenv "TERM"))
            (:dumb-term config)))
     (is (= (format "Terminal is %s" "smart")
            (:smart-term config)))))
+
+(deftest envf-test
+  (let [config (read-config "test/aero/config.edn")]
+    (is (= (format "Terminal is %s" (System/getenv "TERM"))
+           (:dumb-term-envf config)))))
 
 (deftest prop-test
   (let [config (read-config "test/aero/config.edn")]


### PR DESCRIPTION
The motivation behind this PR is to follow-up with a PR to Joplin which replaces `load-config` with Aero's `read-config` as described in this issue: https://github.com/juxt/joplin/issues/89.

Adding `envf` to Aero means it can be a drop-in replacement. The alternative would be to remove `envf` from Joplin and change all the docs and examples with the `#join [ ... #env ]` syntax which, although is slightly more sophisticated (because `envf` doesn't currently support `#or`), is a fairly large affair and is a breaking change. 