### PR TITLE
* add support for reading edn values from strings via #read-edn + #read-eval

### DIFF
--- a/src/aero/core.clj
+++ b/src/aero/core.clj
@@ -93,6 +93,10 @@
   [opts tag value]
   (apply str value))
 
+(defmethod reader 'read-edn
+  [opts tag value]
+  (some-> value str edn/read-string))
+
 (defn- get-in-ref
   [config]
   (letfn [(get-in-conf [m]

--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -23,4 +23,6 @@
  :triple-or #or [#env "DUMMY" #prop "DUMMY" "dummy"]
  :prop #prop "DUMMY"
  :network-call #expensive-network-call 7
+ :test-read-str #read-edn "[:foo :bar :baz]"
+ :test-read-env #read-edn #prop DUMMY_READ
  }

--- a/test/aero/core_test.clj
+++ b/test/aero/core_test.clj
@@ -55,6 +55,14 @@
     (is (= (format "Terminal is %s" "smart")
            (:smart-term config)))))
 
+(deftest test-read
+  (let [x [:foo :bar :baz]
+        _ (System/setProperty "DUMMY_READ" (str x))
+        config (read-config "test/aero/config.edn")]
+    (is (= x (:test-read-str config)))
+    (is (= x (:test-read-env config)))
+    (System/clearProperty "DUMMY_READ")))
+
 (deftest envf-test
   (let [config (read-config "test/aero/config.edn")]
     (is (= (format "Terminal is %s" (System/getenv "TERM"))


### PR DESCRIPTION
The title should be quite self-explanatory I needed to read collections of keywords for instance (from #env in particular), I started by writing #set #list #vec and I just figured #read-edn would make more sense. And I added (the somewhat controversial) #read-eval for these few cases where you need more power (and potential breakage). 