### PR TITLE
Make ref depend on the parents of target

### DIFF
--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -290,6 +290,7 @@
     (fn [graph [k v]]
       (as-> graph %
         (reduce (fn [acc sk] (dep/depend acc sk k)) % (shorter-variations k))
+        (reduce (fn [acc sk] (dep/depend acc k sk)) % (shorter-variations (:value v)))
         (reduce (fn [acc d] (dep/depend acc k d)) % (ref-dependencies v))))
     (dep/graph)
     (filter


### PR DESCRIPTION
Fixes nested maps inside an #include for example