### PR TITLE
Squashes a reflection warning

### DIFF
--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -149,7 +149,7 @@
                         (try (io/file source)
                              ;; Handle the case where the source isn't file compatible:
                              (catch java.lang.IllegalArgumentException _ nil))]
-               (io/file (.getParent source-file) include)))]
+               (io/file (.getParent ^java.io.File source-file) include)))]
        (if (and fl (.exists fl))
          fl
          (StringReader. (pr-str {:aero/missing-include include}))))))


### PR DESCRIPTION
This PR squashes a reflection warning that shows up when downstream consumers of aero run `lein check` on their own code, thereby obscuring reflection warnings in their own code.