### PR TITLE
Use `aero` to namespace tagged literals and deprecate unqualified tags

### DIFF
--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -1,33 +1,33 @@
 {:greeting "Hello World!"
- :flavor #myflavor :favorite
- :dumb-term #join ["Terminal is " #env TERM]
- :smart-term #join ["Terminal is " #or [#env NONE "smart"]]
- :dumb-term-envf #envf ["Terminal is %s" TERM]
- :flavor-string #join ["My favorite flavor is " #or [#env TERM "flaa"] " " #myflavor :favorite]
+ :flavor #my/flavor :favorite
+ :dumb-term #aero/join ["Terminal is " #aero/env TERM]
+ :smart-term #aero/join ["Terminal is " #aero/or [#aero/env NONE "smart"]]
+ :dumb-term-envf #aero/envf ["Terminal is %s" TERM]
+ :flavor-string #aero/join ["My favorite flavor is " #aero/or [#aero/env TERM "flaa"] " " #my/flavor :favorite]
  :test ^:ref [:greeting]
- :remote #include "included.edn"
+ :remote #aero/include "included.edn"
  :test-nested ^:ref [:test]
- :port #profile {:dev 8000
-                 :prod 80}
- :True-boolean #boolean "True"
- :true-boolean #boolean "true"
- :false-boolean #boolean "false"
- :trivial-false-boolean #boolean "OTHER"
- :nil-false-boolean #boolean ""
- :long #long "1234"
- :double #double "4567.8"
- :keyword #keyword "foo/bar"
- :already-a-keyword #keyword :foo/bar
- :env-keyword #keyword #or [#env KEYWORD "abc"]
- :dummy #or [#env "DUMMY" "dummy"]
- :triple-or #or [#env "DUMMY" #prop "DUMMY" "dummy"]
- :prop #prop "DUMMY"
- :network-call #expensive-network-call 7
- :test-read-str #read-edn "[:foo :bar :baz]"
- :test-read-env #read-edn #prop DUMMY_READ
+ :port #aero/profile {:dev 8000
+                      :prod 80}
+ :True-boolean #aero/boolean "True"
+ :true-boolean #aero/boolean "true"
+ :false-boolean #aero/boolean "false"
+ :trivial-false-boolean #aero/boolean "OTHER"
+ :nil-false-boolean #aero/boolean ""
+ :long #aero/long "1234"
+ :double #aero/double "4567.8"
+ :keyword #aero/keyword "foo/bar"
+ :already-a-keyword #aero/keyword :foo/bar
+ :env-keyword #aero/keyword #aero/or [#aero/env KEYWORD "abc"]
+ :dummy #aero/or [#aero/env "DUMMY" "dummy"]
+ :triple-or #aero/or [#aero/env "DUMMY" #aero/prop "DUMMY" "dummy"]
+ :prop #aero/prop "DUMMY"
+ :network-call #my/expensive-network-call 7
+ :test-read-str #aero/read-edn "[:foo :bar :baz]"
+ :test-read-env #aero/read-edn #aero/prop DUMMY_READ
 
  :referencing-network-call ^:ref [:network-call]
 
  :key-part :b
  :refer-me {:a {:b {1234 :sentinel}}}
- :complex-ref #ref [:refer-me :a #ref [:key-part] #ref [:long]]}
+ :complex-ref #aero/ref [:refer-me :a #aero/ref [:key-part] #aero/ref [:long]]}

--- a/test/aero/core_test.cljc
+++ b/test/aero/core_test.cljc
@@ -18,13 +18,13 @@
   #?(:clj (System/getenv (str s)))
   #?(:cljs (aget js/process.env s)))
 
-(defmethod reader 'expensive-network-call
-   [_ tag value]
-   (deferred
-     (swap! network-call-count inc)
-     (inc value)))
+(defmethod reader 'my/expensive-network-call
+  [_ tag value]
+  (deferred
+    (swap! network-call-count inc)
+    (inc value)))
 
-(defmethod reader 'myflavor
+(defmethod reader 'my/flavor
   [opts tag value]
   (if (= value :favorite) :chocolate :vanilla))
 
@@ -192,3 +192,43 @@
   (let [before-call-count @network-call-count
         config (read-config "test/aero/config.edn")]
     (is (= (inc before-call-count) @network-call-count))))
+
+#?(:clj
+   (defmacro return-stderr-stream [& body]
+     `(let [sw# (java.io.StringWriter.)]
+        (binding [*err* sw#]
+          ~@body)
+        (str sw#))))
+
+#?(:clj
+   (deftest deprecation-test
+     (is (= (return-stderr-stream
+             (read-config "test/aero/deprecated-config.edn"))
+            (clojure.string/join "\n"
+                                 ["WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #long is decrecated; use #aero/long instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #ref is decrecated; use #aero/ref instead."
+                                  "WARNING: #include is decrecated; use #aero/include instead."
+                                  "WARNING: #env is decrecated; use #aero/env instead."
+                                  "WARNING: #or is decrecated; use #aero/or instead."
+                                  "WARNING: #join is decrecated; use #aero/join instead."
+                                  "WARNING: #double is decrecated; use #aero/double instead."
+                                  "WARNING: #hostname is decrecated; use #aero/hostname instead."
+                                  "WARNING: #profile is decrecated; use #aero/profile instead."
+                                  "WARNING: #merge is decrecated; use #aero/merge instead."
+                                  "WARNING: #keyword is decrecated; use #aero/keyword instead."
+                                  "WARNING: #read-edn is decrecated; use #aero/read-edn instead."
+                                  "WARNING: #prop is decrecated; use #aero/prop instead."
+                                  "WARNING: #envf is decrecated; use #aero/envf instead."
+                                  "WARNING: #user is decrecated; use #aero/user instead."
+                                  "WARNING: #boolean is decrecated; use #aero/boolean instead."
+                                  ""])))))

--- a/test/aero/deprecated-config.edn
+++ b/test/aero/deprecated-config.edn
@@ -1,0 +1,18 @@
+{:greeting "Hello World!"
+ :smart-term #join ["Terminal is " #or [#env NONE "smart"]]
+ :dumb-term-envf #envf ["Terminal is %s" TERM]
+ :remote #include "included.edn"
+ :port #profile {:dev 8000
+                 :prod 80}
+ :true-boolean #boolean "true"
+ :long #long "1234"
+ :double #double "4567.8"
+ :keyword #keyword "foo/bar"
+ :prop #prop "DUMMY"
+ :test-read-str #read-edn "[:foo :bar :baz]"
+ :hostname #hostname {"emerald" 10}
+ :user #user {"dbowie" 69}
+ :merge #merge [{:foo :bar} {:foo :zip}]
+ :key-part :b
+ :refer-me {:a {:b {1234 :sentinel}}}
+ :complex-ref #ref [:refer-me :a #ref [:key-part] #ref [:long]]}

--- a/test/aero/hosts.edn
+++ b/test/aero/hosts.edn
@@ -1,4 +1,4 @@
-{:color #hostname {"emerald" "green"
-                   #{"diamond"} "white"
-                   :default "black"}
- :weight #hostname {"emerald" 10}}
+{:color #aero/hostname {"emerald" "green"
+                        #{"diamond"} "white"
+                        :default "black"}
+ :weight #aero/hostname {"emerald" 10}}

--- a/test/aero/includes.edn
+++ b/test/aero/includes.edn
@@ -1,6 +1,6 @@
-#include #profile {:relative "sub/includes.edn"
-                   :relative-abs #join [#env "PWD" "/test/aero/sub/includes.edn"]
-                   :resource "aero/sub/includes.edn"
-                   :file "test/aero/sub/includes.edn"
-                   :file-does-not-exist "goodluck.edn"
-                   :map :sub-includes}
+#aero/include #aero/profile {:relative "sub/includes.edn"
+                             :relative-abs #aero/join [#aero/env "PWD" "/test/aero/sub/includes.edn"]
+                             :resource "aero/sub/includes.edn"
+                             :file "test/aero/sub/includes.edn"
+                             :file-does-not-exist "goodluck.edn"
+                             :map :sub-includes}

--- a/test/aero/long_prop.edn
+++ b/test/aero/long_prop.edn
@@ -1,1 +1,1 @@
-{:long-prop #long #prop "FOO"}
+{:long-prop #aero/long #aero/prop "FOO"}

--- a/test/aero/sub/includes.edn
+++ b/test/aero/sub/includes.edn
@@ -1,5 +1,5 @@
-#include #profile {:relative "../valid.edn"
-                   :relative-abs "../valid.edn"
-                   :resource "aero/valid.edn"
-                   :file "test/aero/valid.edn"
-                   :map :valid-file}
+#aero/include #aero/profile {:relative "../valid.edn"
+                             :relative-abs "../valid.edn"
+                             :resource "aero/valid.edn"
+                             :file "test/aero/valid.edn"
+                             :map :valid-file}


### PR DESCRIPTION
Fixes #44