### PR TITLE
Fix nodejs module requires

### DIFF
--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -14,13 +14,12 @@
                      [goog.string :as gstring]
                      goog.string.format
                      [clojure.walk :refer [walk postwalk]]
-                     [aero.vendor.dependency.v0v2v0.com.stuartsierra.dependency :as dep])))
+                     [aero.vendor.dependency.v0v2v0.com.stuartsierra.dependency :as dep]
+                     ["os" :as os]
+                     ["fs" :as fs]
+                     ["path" :as path])))
 
 (declare read-config)
-
-#?(:cljs (def os (nodejs/require "os")))
-#?(:cljs (def fs (nodejs/require "fs")))
-#?(:cljs (def path (nodejs/require "path")))
 
 (defmulti reader (fn [opts tag value] tag))
 
@@ -90,7 +89,7 @@
 (defmethod reader 'hostname
   [{:keys [hostname]} tag value]
   (let [hostn (or hostname #?(:clj (env "HOSTNAME")
-                              :cljs (os.hostname)))]
+                              :cljs (os/hostname)))]
     (or
      (some (fn [[k v]]
              (when (or (= k hostn)
@@ -126,7 +125,7 @@
   [opts tag value]
   (some-> value str edn/read-string))
 
-(defmethod aero.core/reader 'merge
+(defmethod reader 'merge
   [opts tag values]
   (apply merge values))
 
@@ -175,9 +174,9 @@
   {:profile :default
    :resolver #?(:clj adaptive-resolver
                 :cljs (fn [source include]
-                        (if (path.isAbsolute include)
+                        (if (path/isAbsolute include)
                           include
-                          (path.join source ".." include))))})
+                          (path/join source ".." include))))})
 
 ;; The rationale for deferreds is to realise some values after the
 ;; config has been read. This allows certain expensive operations to
@@ -358,7 +357,7 @@
           ;; post-processed tags with declared data readers
           :readers {}
           :default tag-wrapper}
-         (fs.readFileSync source "utf-8"))))))
+         (fs/readFileSync source "utf-8"))))))
 
 (defn read-config
   "First argument is a string URL to the file. To read from the

--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -10,7 +10,6 @@
            [aero.vendor.dependency.v0v2v0.com.stuartsierra.dependency :as dep]))
   #?(:clj (:import (java.io StringReader)))
   #?(:cljs (:require [cljs.tools.reader :as edn]
-                     [cljs.nodejs :as nodejs]
                      [goog.string :as gstring]
                      goog.string.format
                      [clojure.walk :refer [walk postwalk]]

--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -20,6 +20,7 @@
 
 #?(:cljs (def os (nodejs/require "os")))
 #?(:cljs (def fs (nodejs/require "fs")))
+#?(:cljs (def path (nodejs/require "path")))
 
 (defmulti reader (fn [opts tag value] tag))
 


### PR DESCRIPTION
Add missing require for the 'path' nodejs module when on cljs, and update to use the cleaner `(require '["fs" :as fs])` style rather than using `cljs.nodejs/require`. This allows for easier advanced compilation.