### PR TITLE
eastwood and cljfmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - checkout
+      - run: lein eastwood
+      - run: lein cljfmt check
       - run: lein test
 
   test-cljs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,20 @@ jobs:
 
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - clj-deps-{{ checksum "project.clj" }}
+
+      - run: lein deps
       - run: lein eastwood
       - run: lein cljfmt check
       - run: lein test
+      - save_cache:
+          paths:
+            - ~/.m2/repository
+            - ~/.lein
+
+          key: clj-deps-{{ checksum "project.clj" }}
 
   test-cljs:
     docker:

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,11 @@
   :url "http://github.com/juxt/aero"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies []
+
   :plugins [[lein-shell "0.5.0"]]
 
   :aliases {"test-all" ["do" ["test"] ["shell" "./lumo-test"]]}
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]]}})
+  :profiles
+  {:provided {:dependencies [[org.clojure/clojure "1.8.0"]]}
+   :dev {:plugins [[lein-cljfmt "0.5.7"]
+                   [jonase/eastwood "0.3.4"]]}})


### PR DESCRIPTION
Enable dependencies caching and add cljfmt and eastwood checks.
I don't know if you follow these tools already but I noticed that they were both currently given 0 warnings so it might be worth to enable them to keep it like that going forward.