### PR TITLE
Add split and split-re tags (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ Use `#or` when you want to provide a list of possibilities, perhaps with a defau
              #env PROD_PASSWD]}
 ```
 
+### split
+
+`#split` is used to split a string with comma. These values often come from
+environment variables that lack structure and thus use delimiters.
+
+```clojure
+{:hosts #split "app1.host.com,app2.host.com"}
+
+{:hosts #split #env APP_HOSTS}
+```
+
+### split-re
+
+`#split-re` works the same but allows to specify a custom separator as the first
+item of the following vector. As EDN doesn't support `#"regex"` syntax, use a
+plain string which gets converted with `re-pattern` under the hood:
+
+```clojure
+{:hosts #split-re ["\\t" "app1.host.com\tapp2.host.com"]}
+```
+
 ### profile
 
 Use profile as a kind of reader conditional.

--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -6,6 +6,7 @@
      [expand expand-scalar-repeatedly expand-case eval-tagged-literal
       reassemble kv-seq]]
     [aero.impl.walk :refer [postwalk]]
+    [clojure.string :as str]
     #?@(:clj [[clojure.edn :as edn]
               [aero.impl.macro :as macro]]
         :cljs [[cljs.tools.reader.edn :as edn]
@@ -100,6 +101,19 @@
 (defmethod reader 'merge
   [opts tag values]
   (apply merge values))
+
+(letfn [(-split [value re]
+          (if-not (str/blank? value)
+            (str/split value re)
+            []))]
+
+  (defmethod reader 'split
+    [opts tag value]
+    (-split value #","))
+
+  (defmethod reader 'split-re
+    [opts tag [re value]]
+    (-split value (re-pattern re))))
 
 #?(:clj
    (defn relative-resolver [source include]
@@ -240,7 +254,7 @@
                                    ::value tl})))
       (assoc expansion ::value (get env value)))))
 
-(defmethod eval-tagged-literal 'profile 
+(defmethod eval-tagged-literal 'profile
   [tl opts env ks]
   (expand-case (:profile opts) tl opts env ks))
 

--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -14,6 +14,10 @@
  :false-boolean #boolean "false"
  :trivial-false-boolean #boolean "OTHER"
  :nil-false-boolean #boolean ""
+ :split-comma #split "host1,host2,host3"
+ :split-comma-nil #split nil
+ :split-comma-empty #split ""
+ :split-re #split-re ["\\t" "foo\tbar\tbaz"]
  :long #long "1234"
  :double #double "4567.8"
  :keyword #keyword "foo/bar"

--- a/test/aero/core_test.cljc
+++ b/test/aero/core_test.cljc
@@ -151,6 +151,18 @@
   (let [config (read-config "test/aero/config.edn" {:profile :dev})]
     (is (= "dummy" (:dummy config)))))
 
+(deftest split-test
+  (let [config (read-config "test/aero/config.edn" {:profile :dev})]
+    (is (= ["host1" "host2" "host3"]
+           (:split-comma config)))
+    (is (= [] (:split-comma-nil config)))
+    (is (= [] (:split-comma-empty config)))))
+
+(deftest split-re-test
+  (let [config (read-config "test/aero/config.edn" {:profile :dev})]
+    (is (= ["foo" "bar" "baz"]
+           (:split-re config)))))
+
 #?(:clj
    (deftest resolver-tests
      (let [source (io/resource "aero/includes.edn")]


### PR DESCRIPTION
fixes #55 

This PR adds two more reader tags: `#split` and `#split-re`. According to my experience, both tags are useful. Most of our projects carry code to extend built-int tags with these ones to accept comma-separated values from Env vars.

Usage:

```clojure
{:hosts #split "app1.host.com,app2.host.com"}

{:hosts #split #env APP_HOSTS}

{:hosts #split-re ["\\t" "app1.host.com\tapp2.host.com"]}
```
