### PR TITLE
Use a string property to illustrate #or + #env

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Use `#envf` to insert environment variables into a formatted string.
 Use `#or` when you want to provide a list of possibilities, perhaps with a default at the end.
 
 ```clojure
-{:port #or [#env PORT 8080]}
+{:user #or [#env USER "alice"]}
 ```
 
 ### join


### PR DESCRIPTION
Using a number in the example is misleading since it produces either a string or a long. Better use something that isn't a number to begin with