### PR TITLE
Pass keys to tag readers via opts.

### DIFF
--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -217,13 +217,23 @@
   (fn [v]
     (tagged-literal (:tag tl) v)))
 
+(defn- pop*
+  [ks]
+  ;; pop doesn't work with clojure.lang.Cons so we use pop
+  ;; for vector and rest for anything that resembles a list
+  (if (vector? ks)
+    (pop ks)
+    (rest ks)))
+
 (defmethod eval-tagged-literal :default
   [tl opts env ks]
   (let [{:keys [:aero.core/incomplete?] :as expansion}
         (expand (:form tl) opts env ks)]
     (if incomplete?
       (update expansion ::value (rewrap tl))
-      (update expansion ::value #(reader opts (:tag tl) %)))))
+      (update expansion ::value #(reader (assoc opts :key-path (pop* ks))
+                                         (:tag tl)
+                                         %)))))
 
 (defmethod eval-tagged-literal 'ref
   [tl opts env ks]

--- a/test/aero/core_test.cljc
+++ b/test/aero/core_test.cljc
@@ -36,6 +36,10 @@
   [opts tag value]
   (if (= value :favorite) :chocolate :vanilla))
 
+(defmethod reader 'return-key-path
+  [opts _ _]
+  (:key-path opts))
+
 (deftest basic-test
   (let [config (read-config "test/aero/config.edn")]
     (is (= "Hello World!" (:greeting config))))
@@ -250,3 +254,10 @@
     {:a :b}
     #{:a :b}
     '(1)))
+
+(deftest pass-keys-to-reader
+  (is (= [:a :b :c]
+         (get-in (read-config
+                  (string-reader
+                   "{:a {:b {:c #return-key-path 1}}}"))
+          [:a :b :c]))))


### PR DESCRIPTION
Passes the key path to tag readers as `:key-path` in the opts map.

An example of use case for this is a `#required` tag reader that throws an exception when the value is nil. The key path needs to be included in the exception message to indicate which key in configuration is the offending key. So if we have a configuration like:
```clojure
{:a {:b {:c #required #env "FOO"}}}
```
It would throw an exception with a message like `Required key [:a :b :c]`.