### PR TITLE
JUXT Slack links and automated tests badge update in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aero
 
-[![Join the chat at https://gitter.im/juxt/aero](https://badges.gitter.im/juxt/aero.svg)](https://gitter.im/juxt/aero?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+![Workflow](https://github.com/juxt/aero/actions/workflows/tests.yml/badge.svg)
 
 (<b>a</b>ero is <b>e</b>dn <b>r</b>eally, <b>o</b>k?)
 
@@ -13,8 +13,6 @@ A small library for explicit, intentful configuration.
 Add the following dependency to your `project.clj` file
 
 [![Clojars Project](http://clojars.org/aero/latest-version.svg)](http://clojars.org/aero)
-
-[![Build Status](https://circleci.com/gh/juxt/aero.svg?style=svg)](https://circleci.com/gh/juxt/aero)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Aero
 
 ![Workflow](https://github.com/juxt/aero/actions/workflows/tests.yml/badge.svg)
+[![Join the chat at https://clojurians.slack.com/archives/C0CFGN25D](
+https://badgen.net/badge/chat/on%20slack/purple?icon=slack
+)](https://clojurians.slack.com/archives/C0CFGN25D)
 
 (<b>a</b>ero is <b>e</b>dn <b>r</b>eally, <b>o</b>k?)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aero
 
-![Workflow](https://github.com/juxt/aero/actions/workflows/tests.yml/badge.svg)
+![Workflow](https://github.com/juxt/aero/actions/workflows/tests.yml/badge.svg?branch=master)
 [![Join the chat at https://clojurians.slack.com/archives/C0CFGN25D](
 https://badgen.net/badge/chat/on%20slack/purple?icon=slack
 )](https://clojurians.slack.com/archives/C0CFGN25D)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Also, see these arguments [against](https://gist.github.com/telent/9742059).
 
 Fortunately for Clojure developers like us, most of the tech to read configuration in a safe, secure and extensible way already exists in the Clojure core library (EDN).
 
+## Community
+
+If you you have any questions, don't hesitate to write a message in [JUXT's Clojurians Slack channel](https://clojurians.slack.com/archives/C0CFGN25D)
+
 ## Tag literals
 
 Aero provides a small library of tag literals.


### PR DESCRIPTION
Adds Community section and Slack GH badge linking to the #JUXT Clojurian Slack channel. Also updates the old CircleCI status badge for the current GH Action flow status.