### PR TITLE
feat: Add support for #concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,21 @@ Use `#or` when you want to provide a list of possibilities, perhaps with a defau
 
 `#join` is used as a string builder, useful in a variety of situations such as building up connection strings.
 
-``` clojure
+```clojure
 {:url #join ["jdbc:postgresql://psq-prod/prod?user="
              #env PROD_USER
              "&password="
              #env PROD_PASSWD]}
+```
+
+### concat
+
+`#concat` is used to concatenate colls, useful when you need to handle lists.
+
+```clojure
+{:args #concat [["aaa" "bbb"]
+                #profile {:default ["--prod"]
+                          :dev     ["--dev" "--verbose"]}]}
 ```
 
 ### profile

--- a/src/aero/core.cljc
+++ b/src/aero/core.cljc
@@ -93,6 +93,10 @@
   [opts tag value]
   (apply str value))
 
+(defmethod reader 'concat
+  [opts tag value]
+  (apply concat value))
+
 (defmethod reader 'read-edn
   [opts tag value]
   (some-> value str edn/read-string))

--- a/test/aero/config.edn
+++ b/test/aero/config.edn
@@ -4,6 +4,7 @@
  :smart-term #join ["Terminal is " #or [#env NONE "smart"]]
  :dumb-term-envf #envf ["Terminal is %s" TERM]
  :flavor-string #join ["My favorite flavor is " #or [#env TERM "flaa"] " " #myflavor :favorite]
+ :my-list-argv #concat [["this" "is" "args"] ["and" "here" "other" "args"] [] nil]
  :test ^:ref [:greeting]
  :remote #include "included.edn"
  :test-nested ^:ref [:test]

--- a/test/aero/core_test.cljc
+++ b/test/aero/core_test.cljc
@@ -69,6 +69,11 @@
     (is (= (#?(:clj format :cljs gstring/format) "Terminal is %s" "smart")
            (:smart-term config)))))
 
+(deftest concat-test
+  (let [config (read-config "test/aero/config.edn")]
+    (is (= ["this" "is" "args" "and" "here" "other" "args"]
+           (:my-list-argv config)))))
+
 #?(:clj
    (deftest test-read
      (let [x [:foo :bar :baz]


### PR DESCRIPTION
Adding support for `#concat`, allowing the manipulation of vectors within configs. This is really useful when you work with nested aero tags, and want to get a coll within the resulting object, without pushing in the code the logic of removing nils.